### PR TITLE
Rebrand application to GoCard App / skuPulse

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -2,8 +2,8 @@ import 'dotenv/config';
 
 export default {
   expo: {
-    name: 'Glisten SAS',
-    slug: 'school-rfid-app',
+    name: 'GoCard App',
+    slug: 'skuPulse',
     version: '1.0.0',
     orientation: 'portrait',
     icon: './assets/images/icon.png',
@@ -32,7 +32,7 @@ export default {
         foregroundImage: './assets/images/icon.png',
         backgroundColor: '#ffffff',
       },
-      package: 'com.anonymous.SchoolRFIDApp',
+      package: 'com.anonymous.skupulseApp',
       versionCode: 1,
     },
     web: {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,9 +10,9 @@ export default function RootLayout() {
   useEffect(() => {
     const cleanupOldSettings = async () => {
       try {
-        await AsyncStorage.removeItem('@SchoolRFIDApp:signInStart');
-        await AsyncStorage.removeItem('@SchoolRFIDApp:signInEnd');
-        await AsyncStorage.removeItem('@SchoolRFIDApp:signOutStart');
+        await AsyncStorage.removeItem('@skupulseApp:signInStart');
+        await AsyncStorage.removeItem('@skupulseApp:signInEnd');
+        await AsyncStorage.removeItem('@skupulseApp:signOutStart');
         console.log('Cleaned up old time window settings');
       } catch (err) {
         console.error('Error cleaning up old settings:', err);
@@ -20,7 +20,7 @@ export default function RootLayout() {
     };
     cleanupOldSettings();
 
-    AsyncStorage.getItem('@SchoolRFIDApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
+    AsyncStorage.getItem('@skupulseApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
   }, []);
 
   return (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -18,7 +18,7 @@ export default function HomeScreen() {
 
   useEffect(() => {
     resetStudentStatuses().catch((error) => console.error('Error resetting student statuses:', error));
-    AsyncStorage.getItem('@SchoolRFIDApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
+    AsyncStorage.getItem('@skupulseApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
   }, []);
 
   const fetchRecentStudents = async () => {

--- a/app/manual.tsx
+++ b/app/manual.tsx
@@ -41,7 +41,7 @@ export default function ManualScreen() {
             await logMessage(data.rfid, student.parentPhone2, message, 'sent');
           }
 
-          const ttsEnabled = (await AsyncStorage.getItem('@SchoolRFIDApp:ttsEnabled')) !== 'false';
+          const ttsEnabled = (await AsyncStorage.getItem('@skupulseApp:ttsEnabled')) !== 'false';
           if (ttsEnabled) {
             Tts.speak(event === 'in' ? `Hello ${student.name}, welcome to school` : `Bye bye ${student.name}`);
           }

--- a/app/scan.tsx
+++ b/app/scan.tsx
@@ -49,7 +49,7 @@ export default function ScanScreen() {
       return;
     }
 
-    const continuousScan = (await AsyncStorage.getItem('@SchoolRFIDApp:continuousScanEnabled')) !== 'false';
+    const continuousScan = (await AsyncStorage.getItem('@skupulseApp:continuousScanEnabled')) !== 'false';
 
     await startNfc(
       (data: NfcSuccessData) => {

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -15,9 +15,9 @@ export default function SettingsScreen() {
   const [manualClockEnabled, setManualClockEnabled] = useState(true);
 
   useEffect(() => {
-    AsyncStorage.getItem('@SchoolRFIDApp:ttsEnabled').then((value) => setTtsEnabled(value !== 'false'));
-    AsyncStorage.getItem('@SchoolRFIDApp:continuousScanEnabled').then((value) => setContinuousScanEnabled(value !== 'false'));
-    AsyncStorage.getItem('@SchoolRFIDApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
+    AsyncStorage.getItem('@skupulseApp:ttsEnabled').then((value) => setTtsEnabled(value !== 'false'));
+    AsyncStorage.getItem('@skupulseApp:continuousScanEnabled').then((value) => setContinuousScanEnabled(value !== 'false'));
+    AsyncStorage.getItem('@skupulseApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
   }, []);
 
   if (!isAdmin) {
@@ -52,17 +52,17 @@ export default function SettingsScreen() {
 
   const handleTtsToggle = async (value: boolean) => {
     setTtsEnabled(value);
-    await AsyncStorage.setItem('@SchoolRFIDApp:ttsEnabled', value.toString());
+    await AsyncStorage.setItem('@skupulseApp:ttsEnabled', value.toString());
   };
 
   const handleContinuousScanToggle = async (value: boolean) => {
     setContinuousScanEnabled(value);
-    await AsyncStorage.setItem('@SchoolRFIDApp:continuousScanEnabled', value.toString());
+    await AsyncStorage.setItem('@skupulseApp:continuousScanEnabled', value.toString());
   };
 
   const handleManualClockToggle = async (value: boolean) => {
     setManualClockEnabled(value);
-    await AsyncStorage.setItem('@SchoolRFIDApp:manualClockEnabled', value.toString());
+    await AsyncStorage.setItem('@skupulseApp:manualClockEnabled', value.toString());
   };
 
   return (

--- a/app/students.tsx
+++ b/app/students.tsx
@@ -126,7 +126,7 @@ export default function StudentsScreen() {
         style: 'destructive',
         onPress: async () => {
           try {
-            await AsyncStorage.setItem('@SchoolRFIDApp:students', JSON.stringify([]));
+            await AsyncStorage.setItem('@skupulseApp:students', JSON.stringify([]));
             setStudents([]);
             setFilteredStudents([]);
             Alert.alert('Success', 'All students deleted successfully!');
@@ -163,7 +163,7 @@ export default function StudentsScreen() {
   const handleResetStatuses = async () => {
     try {
       await resetStudentStatuses();
-      await AsyncStorage.removeItem('@SchoolRFIDApp:lastResetTimestamp');
+      await AsyncStorage.removeItem('@skupulseApp:lastResetTimestamp');
       fetchStudents();
       Alert.alert('Success', 'Student statuses reset successfully!');
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "schoolrfidapp",
+  "name": "skupulseapp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "schoolrfidapp",
+      "name": "skupulseapp",
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "schoolrfidapp",
+  "name": "skupulseapp",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
@@ -73,8 +73,8 @@
   },
   "private": true,
   "expo": {
-    "name": "Glisten SAS",
-    "slug": "school-rfid-app",
+    "name": "GoCard App",
+    "slug": "skuPulse",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
@@ -113,7 +113,7 @@
         "foregroundImage": "./assets/images/icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "com.anonymous.SchoolRFIDApp",
+      "package": "com.anonymous.skupulseApp",
       "versionCode": 1,
       "targetSdkVersion": 34
     },

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -23,8 +23,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isAdmin, setIsAdmin] = useState(false);
 
   // Default admin creds (can be updated later)
-  const ADMIN_STORAGE_KEY = '@SchoolRFIDApp:adminCreds';
-  const ADMIN_STATE_KEY = '@SchoolRFIDApp:adminState';
+  const ADMIN_STORAGE_KEY = '@skupulseApp:adminCreds';
+  const ADMIN_STATE_KEY = '@skupulseApp:adminState';
 
   useEffect(() => {
     // Check if admin is already logged in on app start

--- a/src/nfc/nfcManager.ts
+++ b/src/nfc/nfcManager.ts
@@ -88,7 +88,7 @@ export const startNfc = async (
       await logAttendance(rfid, event);
       await updateStudent(rfid, { ...student, lastEvent: { event, timestamp: scanTime } });
 
-      const ttsEnabled = (await AsyncStorage.getItem('@SchoolRFIDApp:ttsEnabled')) !== 'false';
+      const ttsEnabled = (await AsyncStorage.getItem('@skupulseApp:ttsEnabled')) !== 'false';
       let smsError: string | undefined;
       try {
         await sendSMS(rfid, student.parentPhone, message);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -31,10 +31,10 @@ export interface MessageLog {
   studentName?: string;
 }
 
-const STUDENTS_KEY = '@SchoolRFIDApp:students';
-const ATTENDANCE_KEY = '@SchoolRFIDApp:attendance';
-const MESSAGE_KEY = '@SchoolRFIDApp:messages';
-const LAST_RESET_KEY = '@SchoolRFIDApp:lastResetTimestamp';
+const STUDENTS_KEY = '@skupulseApp:students';
+const ATTENDANCE_KEY = '@skupulseApp:attendance';
+const MESSAGE_KEY = '@skupulseApp:messages';
+const LAST_RESET_KEY = '@skupulseApp:lastResetTimestamp';
 
 export const registerStudent = async (student: Student): Promise<void> => {
   const students = await getAllStudents();


### PR DESCRIPTION
This commit performs a comprehensive rebranding of the application.

- The project name has been changed from 'SchoolRFIDApp' to 'skupulseApp' and the slug from 'school-rfid-app' to 'skuPulse'.
- All occurrences of the old names have been replaced throughout the codebase, including in configuration files, AsyncStorage keys, and package names.
- The display name in `app.config.js` has been updated from 'Glisten SAS' to 'GoCard App'.