### PR TITLE
Fix: Correct API URL for all endpoints

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -24,7 +24,7 @@ const handleApiResponse = async (response: Response) => {
     }
 };
 
-const API_URL = 'https://skupulse-8k3l.onrender.com';
+const API_URL = 'https://skupulse-8k3l.onrender.com/api';
 
 const getAuthToken = async () => {
   return await AsyncStorage.getItem('@skupulseApp:authToken');


### PR DESCRIPTION
The API URL in `src/utils/api.ts` was missing the `/api` path, which caused all API requests to fail with a 404 Not Found error.

This commit adds the `/api` path to the `API_URL` constant, ensuring that all API calls are directed to the correct endpoints.