### PR TITLE
Fix: Send username in login payload instead of email

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -38,7 +38,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = async (username: string, password: string): Promise<boolean> => {
     try {
-      // The username from the form is the email
       const data = await loginUser(username, password);
 
       if (data.token && data.school.id) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -30,14 +30,14 @@ const getAuthToken = async () => {
   return await AsyncStorage.getItem('@skupulseApp:authToken');
 };
 
-export const loginUser = async (email: string, password: string) => {
+export const loginUser = async (username: string, password: string) => {
   try {
     const response = await fetch(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ username, password }),
     });
     return handleApiResponse(response);
   } catch (error) {


### PR DESCRIPTION
The application was previously sending an `email` field in the login request payload, but the backend API expects a `username` field. This was causing "Invalid credentials" errors.

This commit corrects the `loginUser` function in `src/utils/api.ts` to send a `username` in the JSON body, as per the backend's Swagger documentation. The related frontend code, which was incorrectly changed to use `email`, has been reverted to use `username` consistently.