### PR TITLE
Fix: Correctly handle the login API response

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -40,8 +40,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       const data = await loginUser(username, password);
 
-      if (data.token && data.school.id) {
-        await saveSession(data.token, data.school.id);
+      if (data.token && data.user && data.user.userId) {
+        await saveSession(data.token, data.user.userId);
         setIsAdmin(true);
         return true;
       }


### PR DESCRIPTION
The application was expecting a `school.id` in the login response, but the backend returns a `user` object with a `userId`. This caused a TypeError (`Cannot read properties of undefined (reading 'id')`) upon successful login.

This commit updates the `login` function in `AuthContext.tsx` to correctly parse the API response, using the `user.userId` as the `schoolId` for the session. This aligns the frontend with the backend's actual response structure as defined in the Swagger documentation.