### PR TITLE
fix(auth): Correct schoolId path to fix login redirect

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -38,8 +38,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const login = async (username: string, password: string): Promise<boolean> => {
     try {
       const data = await loginUser(username, password);
-      if (data.token && data.user && data.user.schoolId) {
-        await saveSession(data.token, data.user.schoolId);
+      if (data.token && data.user && data.user.school && data.user.school.id) {
+        await saveSession(data.token, data.user.school.id);
         setIsAdmin(true);
         return true;
       }


### PR DESCRIPTION
This commit resolves a bug where a successful login did not redirect the user away from the login form.

The root cause was an incorrect data access path in `AuthContext.tsx`. The code was attempting to retrieve the school ID from `user.schoolId`, but the API response nests this value at `user.school.id`.

This discrepancy caused the login function to incorrectly determine that the login failed, preventing the subsequent redirect. The `if` condition in the `login` function has been updated to check for and use the correct path (`data.user.school.id`), which resolves the issue.