### PR TITLE
fix(storage): Correctly handle student API response

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -63,9 +63,11 @@ export const getAllStudents = async (): Promise<Student[]> => {
       const jsonValue = await AsyncStorage.getItem(STUDENTS_KEY);
       return jsonValue ? JSON.parse(jsonValue) : [];
     }
-    const students = await apiGetStudents(schoolId);
-    await AsyncStorage.setItem(STUDENTS_KEY, JSON.stringify(students));
-    return students;
+    const apiResponse = await apiGetStudents(schoolId);
+    // The API returns an object { total, students }, so we extract the array
+    const studentList = apiResponse.students || [];
+    await AsyncStorage.setItem(STUDENTS_KEY, JSON.stringify(studentList));
+    return studentList;
   } catch (error) {
     console.error('Failed to fetch students from API, loading from local storage', error);
     const jsonValue = await AsyncStorage.getItem(STUDENTS_KEY);


### PR DESCRIPTION
This commit resolves a `TypeError: studentList.filter is not a function` that occurred on the application's home screen.

The error was caused because the `getAllStudents` function was returning the entire response object from the API (e.g., `{ total: 3, students: [...] }`) instead of just the array of students. Subsequent code that called this function would then attempt to use array methods like `.filter()` on the object, causing a crash.

The `getAllStudents` function in `src/utils/storage.ts` has been modified to correctly parse the API response. It now extracts the `students` array from the response object before saving it to local storage and returning it. This ensures that any part of the application calling this function receives the data in the expected array format.