### PR TITLE
feat: implement automatic logout on session expiration

### DIFF
--- a/app/register.tsx
+++ b/app/register.tsx
@@ -5,6 +5,7 @@ import * as Clipboard from 'expo-clipboard';
 import { router } from 'expo-router';
 import { startNfc, stopNfc } from '../src/nfc/nfcManager';
 import { registerStudent } from '../src/utils/storage';
+import { useApi } from '../src/hooks/useApi';
 
 export default function RegisterScreen() {
   const [name, setName] = useState('');
@@ -14,6 +15,7 @@ export default function RegisterScreen() {
   const [rfid, setRfid] = useState('');
   const [scanning, setScanning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const callApi = useApi();
 
   const handleScanRfid = async () => {
     setScanning(true);
@@ -43,15 +45,16 @@ export default function RegisterScreen() {
       return;
     }
 
-    try {
-      await registerStudent({
-        rfid,
-        name,
-        admissionNumber,
-        parentPhone,
-        parentPhone2: parentPhone2 || undefined,
-        lastEvent: null,
-      });
+    const result = await callApi(() => registerStudent({
+      rfid,
+      name,
+      admissionNumber,
+      parentPhone,
+      parentPhone2: parentPhone2 || undefined,
+      lastEvent: null,
+    }));
+
+    if (result !== null) {
       Alert.alert('Success', 'Student registered successfully!', [
         { text: 'OK', onPress: () => router.replace('/students') },
       ]);
@@ -61,8 +64,6 @@ export default function RegisterScreen() {
       setParentPhone2('');
       setRfid('');
       setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to register student');
     }
   };
 

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+import { Alert } from 'react-native';
+import { AuthContext } from '../context/AuthContext';
+import { SessionExpiredError } from '../utils/errors';
+import { router } from 'expo-router';
+
+export const useApi = () => {
+  const { logout } = useContext(AuthContext);
+
+  const callApi = async <T>(apiCall: () => Promise<T>): Promise<T | null> => {
+    try {
+      return await apiCall();
+    } catch (error) {
+      if (error instanceof SessionExpiredError) {
+        Alert.alert(
+          'Session Expired',
+          'Your session has expired. Please log in again.',
+          [{ text: 'OK', onPress: () => router.push('/') }]
+        );
+        await logout();
+      } else {
+        console.error('API call error:', error);
+        Alert.alert('Error', 'An unexpected error occurred.');
+      }
+      return null;
+    }
+  };
+
+  return callApi;
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,8 +1,13 @@
 // src/utils/api.ts
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Student } from './storage';
+import { SessionExpiredError } from './errors';
 
 const handleApiResponse = async (response: Response) => {
+    if (response.status === 401) {
+        throw new SessionExpiredError();
+    }
+
     const responseText = await response.text();
 
     if (!response.ok) {
@@ -11,7 +16,6 @@ const handleApiResponse = async (response: Response) => {
             const errorData = JSON.parse(responseText);
             errorMessage = errorData.message || errorMessage;
         } catch (e) {
-            // Not a JSON response, use the text
             errorMessage = `${errorMessage}. Server response: ${responseText.substring(0, 200)}...`;
         }
         throw new Error(errorMessage);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,6 @@
+export class SessionExpiredError extends Error {
+  constructor(message = 'Your session has expired. Please log in again.') {
+    super(message);
+    this.name = 'SessionExpiredError';
+  }
+}


### PR DESCRIPTION
When a user's session expires, the application now automatically logs them out and displays an alert.

This is achieved by:
- Introducing a `useApi` hook that wraps all authenticated API calls.
- Modifying the API handler to throw a custom `SessionExpiredError` when a 401 status is received.
- The `useApi` hook catches this error, calls the `logout` function from `AuthContext`, and redirects the user to the home screen.
- Refactoring all components that make authenticated API calls to use the new `useApi` hook.