### PR TITLE
feat: Add missing icon mappings for Android

### DIFF
--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -13,6 +13,18 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  wifi: 'wifi',
+  'qrcode.viewfinder': 'qr-code-scanner',
+  gear: 'settings',
+  'info.circle': 'info-outline',
+  'arrow.clockwise': 'refresh',
+  'creditcard.fill': 'credit-card',
+  'person.fill': 'person',
+  'number.square.fill': 'format-list-numbered',
+  calendar: 'calendar-today',
+  'phone.fill': 'phone',
+  'message.fill': 'message',
+  'exclamationmark.triangle.fill': 'warning',
 } as Partial<
   Record<
     import('expo-symbols').SymbolViewProps['name'],


### PR DESCRIPTION
The application was failing to display icons on the production Android build because the `IconSymbol` component, which falls back to Material Icons on Android, was missing mappings for many of the SF Symbols used in the app.

This change updates the `MAPPING` constant in `components/ui/IconSymbol.tsx` to include all the missing icons, ensuring they are displayed correctly on Android.