### PR TITLE
fix: Load MaterialIcons font to fix missing icons in production

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,19 @@
 // app/_layout.tsx
-import { Stack } from 'expo-router';
+import { Stack, SplashScreen } from 'expo-router';
 import { AuthProvider } from '../src/context/AuthContext';
 import { useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFonts } from 'expo-font';
+import { MaterialIcons } from '@expo/vector-icons';
+
+// Prevent the splash screen from auto-hiding before asset loading is complete.
+SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   const [manualClockEnabled, setManualClockEnabled] = useState(true);
+  const [loaded, error] = useFonts({
+    ...MaterialIcons.font,
+  });
 
   useEffect(() => {
     const cleanupOldSettings = async () => {
@@ -22,6 +30,16 @@ export default function RootLayout() {
 
     AsyncStorage.getItem('@skupulseApp:manualClockEnabled').then((value) => setManualClockEnabled(value !== 'false'));
   }, []);
+
+  useEffect(() => {
+    if (loaded || error) {
+      SplashScreen.hideAsync();
+    }
+  }, [loaded, error]);
+
+  if (!loaded && !error) {
+    return null;
+  }
 
   return (
     <AuthProvider>


### PR DESCRIPTION
The application was not displaying icons in the production Android build because the `MaterialIcons` font was not being explicitly loaded. In Expo, fonts must be loaded using the `useFonts` hook to ensure they are bundled and available in a production build.

This commit modifies the root layout (`app/_layout.tsx`) to:
1.  Import the `useFonts` hook and the `MaterialIcons` font.
2.  Call `useFonts` to load the `MaterialIcons.font`.
3.  Prevent the app from rendering until the font has been loaded by integrating with the splash screen.

This ensures that the icon font is available before any components attempt to use it, resolving the issue of missing icons and unresponsive buttons in the production Android app.