### PR TITLE
Fix: Prevent infinite re-render loop in HomeScreen

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useCallback } from 'react';
 import { Alert } from 'react-native';
 import { AuthContext } from '../context/AuthContext';
 import { SessionExpiredError } from '../utils/errors';
@@ -7,7 +7,7 @@ import { router } from 'expo-router';
 export const useApi = () => {
   const { logout } = useContext(AuthContext);
 
-  const callApi = async <T>(apiCall: () => Promise<T>): Promise<T | null> => {
+  const callApi = useCallback(async <T>(apiCall: () => Promise<T>): Promise<T | null> => {
     try {
       return await apiCall();
     } catch (error) {
@@ -24,7 +24,7 @@ export const useApi = () => {
       }
       return null;
     }
-  };
+  }, [logout]);
 
   return callApi;
 };


### PR DESCRIPTION
The HomeScreen was getting stuck in an infinite re-render loop, causing the UI to freeze. This was due to the `useApi` custom hook creating a new `callApi` function on every render.

This new function instance was part of the dependency array for a `useCallback` hook (`fetchRecentStudents`), which in turn was a dependency for a `useEffect` hook that updated the component's state. This created a cycle of re-renders.

The `callApi` function inside the `useApi` hook is now wrapped in `useCallback` to ensure it is memoized and not recreated on every render. This breaks the infinite loop.