### PR TITLE
feat: Decouple manual clock from main attendance logic

### DIFF
--- a/app/manual.tsx
+++ b/app/manual.tsx
@@ -32,7 +32,6 @@ export default function ManualScreen() {
 
         try {
           await logAttendance(data.rfid, event, true); // Mark as manual
-          await updateStudent(data.rfid, { ...student, lastEvent: { event, timestamp: Date.now() } });
 
           await sendSMS(data.rfid, student.parentPhone, message);
           await logMessage(data.rfid, student.parentPhone, message, 'sent');
@@ -62,7 +61,8 @@ export default function ManualScreen() {
       (err: string) => {
         setError(err);
         setScanning(false);
-      }
+      },
+      true
     );
   };
 


### PR DESCRIPTION
This change decouples the manual clock from the main time-based attendance logic, allowing for repeatable sign-in and sign-out actions at any time of day.

The following changes were made:
- The `startNfc` function in `app/manual.tsx` is now called with the `readOnly` flag set to `true`. This bypasses the time-based validation in `nfcManager.ts`.
- The call to `updateStudent` in `app/manual.tsx` has been removed. This prevents the manual clock from updating the `lastEvent` property, which would otherwise interfere with the main attendance system.