### PR TITLE
Fix: Update app icon path in app.config.js

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -7,7 +7,7 @@ export default {
     slug: 'skuPulse',
     version: '1.0.0',
     orientation: 'portrait',
-    icon: './assets/images/adaptive-icon.png',
+    icon: './assets/images/icon.png',
     scheme: 'myapp',
     userInterfaceStyle: 'automatic',
     newArchEnabled: false,


### PR DESCRIPTION
The app icon was not displaying correctly because the `icon` property in `app.config.js` was pointing to the adaptive icon foreground image (`adaptive-icon.png`) instead of the main app icon file (`icon.png`).

This change corrects the path to point to `assets/images/icon.png`, which will resolve the issue after the app is rebuilt.