### PR TITLE
feat: Shorten student name in SMS messages

### DIFF
--- a/app/manual.tsx
+++ b/app/manual.tsx
@@ -3,6 +3,7 @@ import { View, Text, Button, StyleSheet, Alert } from 'react-native';
 import { startNfc, stopNfc, NfcSuccessData } from '../src/nfc/nfcManager';
 import { getStudent, Student, logAttendance, updateStudent, logMessage } from '../src/utils/storage';
 import { sendSMS } from '../src/utils/sms';
+import { formatStudentName } from '../src/utils/format';
 import Tts from 'react-native-tts';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -26,7 +27,8 @@ export default function ManualScreen() {
         }
 
         const now = new Date();
-        const message = `Dear Parent, ${student.name} has ${
+        const formattedName = formatStudentName(student.name);
+        const message = `Dear Parent, ${formattedName} has ${
           event === 'in' ? 'entered' : 'exited'
         } the school on ${now.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' })} at ${now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true })}`;
 

--- a/src/nfc/nfcManager.ts
+++ b/src/nfc/nfcManager.ts
@@ -1,6 +1,7 @@
 import NfcManager, { NfcEvents } from 'react-native-nfc-manager';
 import { getStudent, updateStudent, logAttendance, Student, logMessage } from '../utils/storage';
 import { sendSMS } from '../utils/sms';
+import { formatStudentName } from '../utils/format';
 import Tts from 'react-native-tts';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -82,7 +83,8 @@ export const startNfc = async (
         return `${hours}:${minutesStr} ${ampm}`;
       };
 
-      const message = `GoSortplux: Dear Parent, ${student.name} has ${
+      const formattedName = formatStudentName(student.name);
+      const message = `GoSortplux: Dear Parent, ${formattedName} has ${
         event === 'in' ? 'entered' : 'exited'
       } the school on ${now.toLocaleDateString('en-US', {
         weekday: 'short',

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,15 @@
+export const formatStudentName = (fullName: string): string => {
+  if (!fullName) {
+    return '';
+  }
+
+  const names = fullName.trim().split(' ');
+  if (names.length <= 1) {
+    return fullName;
+  }
+
+  const firstName = names[0];
+  const initials = names.slice(1).map(name => `${name.charAt(0).toUpperCase()}`).join(' ');
+
+  return `${firstName} ${initials}`;
+};


### PR DESCRIPTION
This commit introduces a new utility function `formatStudentName` to shorten a student's full name to their first name followed by the initials of their other names.

This function is used in both the manual and NFC attendance flows to ensure that the student's name is formatted consistently in the SMS messages sent to parents.

This change addresses the user's request to reduce the cost of sending SMS messages by shortening the student's name.